### PR TITLE
Update terraform-atlassian-api-client version to v1.3.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/hashicorp/terraform-plugin-framework-validators v0.12.0
 	github.com/yunarta/golang-quality-of-life-pack v1.0.0
 	github.com/yunarta/terraform-api-transport v1.0.0
-	github.com/yunarta/terraform-atlassian-api-client v1.3.0
+	github.com/yunarta/terraform-atlassian-api-client v1.3.1
 	github.com/yunarta/terraform-provider-commons v1.0.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -61,8 +61,8 @@ github.com/yunarta/golang-quality-of-life-pack v1.0.0 h1:T0xwfFnD61x6Nz9ej+tRWK6
 github.com/yunarta/golang-quality-of-life-pack v1.0.0/go.mod h1:Qw+9tWyqPJxxHLyuxCo5xCNwmfG/TMOt8Vkfq0bl9TU=
 github.com/yunarta/terraform-api-transport v1.0.0 h1:7Zp9FiZm4QG8hIPj/odCVjaqXfRzH2M7uVrip+SFWwI=
 github.com/yunarta/terraform-api-transport v1.0.0/go.mod h1:KCRrG4fBwMob0+dhyhgZm6ZEsJTk3BmAwjcVlSeq4I0=
-github.com/yunarta/terraform-atlassian-api-client v1.3.0 h1:UKlRUGkH1YzvAY2HqvmoyYwPq35KXTsRmHw4IMKi5M8=
-github.com/yunarta/terraform-atlassian-api-client v1.3.0/go.mod h1:R3gu4RFcs85QBjruvBCQLt3IpMXXl8y6NYmfA976sBM=
+github.com/yunarta/terraform-atlassian-api-client v1.3.1 h1:CMGIIdvki9OatbBxgKZzk6h0oVlmsTE7dmcXwc7hpHk=
+github.com/yunarta/terraform-atlassian-api-client v1.3.1/go.mod h1:R3gu4RFcs85QBjruvBCQLt3IpMXXl8y6NYmfA976sBM=
 github.com/yunarta/terraform-provider-commons v1.0.0 h1:Zna6HFHe7iOM5LIsJLYCzSOK1VpfZmkTKsVqdSvwMTs=
 github.com/yunarta/terraform-provider-commons v1.0.0/go.mod h1:cMM6yuj5kv5ugou9T9uOwLARlwlI77OfAJXDXzxPqVM=
 golang.org/x/net v0.20.0 h1:aCL9BSgETF1k+blQaYUBx9hJ9LOGP3gAVemcZlf1Kpo=


### PR DESCRIPTION
The go.mod and go.sum files have been updated to reflect the newer version v1.3.1 of the terraform-atlassian-api-client. This update ensures the use of the most recent features and updates provided by this package.