### PR TITLE
Update terraform-atlassian-api-client to v1.3.13

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/hashicorp/terraform-plugin-framework-validators v0.12.0
 	github.com/yunarta/golang-quality-of-life-pack v1.0.0
 	github.com/yunarta/terraform-api-transport v1.0.1
-	github.com/yunarta/terraform-atlassian-api-client v1.3.12
+	github.com/yunarta/terraform-atlassian-api-client v1.3.13
 	github.com/yunarta/terraform-provider-commons v1.0.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -118,8 +118,8 @@ github.com/yunarta/golang-quality-of-life-pack v1.0.0 h1:T0xwfFnD61x6Nz9ej+tRWK6
 github.com/yunarta/golang-quality-of-life-pack v1.0.0/go.mod h1:Qw+9tWyqPJxxHLyuxCo5xCNwmfG/TMOt8Vkfq0bl9TU=
 github.com/yunarta/terraform-api-transport v1.0.1 h1:WzxCUGs8UJcCYB09ErLLXtu8NGzKIoCfWNlLQTjnYA4=
 github.com/yunarta/terraform-api-transport v1.0.1/go.mod h1:sYdlgKir9SBUVv3GO/m5m7MtJ5o9FK/n4yRpQKmFvjM=
-github.com/yunarta/terraform-atlassian-api-client v1.3.12 h1:rB3afTmlBRZVQnhV9xb6cXf9g6FvV7AXCmuP4Abf3M0=
-github.com/yunarta/terraform-atlassian-api-client v1.3.12/go.mod h1:QOj00CmhhXF+6kb8RBxEULIBEaZe0Bv+xMFmFHCHUIA=
+github.com/yunarta/terraform-atlassian-api-client v1.3.13 h1:Qw62vzMKh6zyZvK6MChJ3bFLNtFUeth7QoPP+XNHsPU=
+github.com/yunarta/terraform-atlassian-api-client v1.3.13/go.mod h1:QOj00CmhhXF+6kb8RBxEULIBEaZe0Bv+xMFmFHCHUIA=
 github.com/yunarta/terraform-provider-commons v1.0.1 h1:xiygGeHQZVxd0GDBu+8O7jqNwbsSzZf+twLRiNWlTmo=
 github.com/yunarta/terraform-provider-commons v1.0.1/go.mod h1:gXzBv5F0F/52m46qPp8hzYrdQSG/VScTnJXf4muldXg=
 golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=


### PR DESCRIPTION
This commit updates the version of the terraform-atlassian-api-client from v1.3.12 to v1.3.13. The updated version was reflected in both the go.sum and go.mod files for the terraform-provider-bitbucket project.