### PR TITLE
Update Terraform provider and replace string modifiers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/yunarta/golang-quality-of-life-pack v1.0.0
 	github.com/yunarta/terraform-api-transport v1.0.1
 	github.com/yunarta/terraform-atlassian-api-client v1.3.13
-	github.com/yunarta/terraform-provider-commons v1.0.1
+	github.com/yunarta/terraform-provider-commons v1.0.2
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -120,8 +120,8 @@ github.com/yunarta/terraform-api-transport v1.0.1 h1:WzxCUGs8UJcCYB09ErLLXtu8NGz
 github.com/yunarta/terraform-api-transport v1.0.1/go.mod h1:sYdlgKir9SBUVv3GO/m5m7MtJ5o9FK/n4yRpQKmFvjM=
 github.com/yunarta/terraform-atlassian-api-client v1.3.13 h1:Qw62vzMKh6zyZvK6MChJ3bFLNtFUeth7QoPP+XNHsPU=
 github.com/yunarta/terraform-atlassian-api-client v1.3.13/go.mod h1:QOj00CmhhXF+6kb8RBxEULIBEaZe0Bv+xMFmFHCHUIA=
-github.com/yunarta/terraform-provider-commons v1.0.1 h1:xiygGeHQZVxd0GDBu+8O7jqNwbsSzZf+twLRiNWlTmo=
-github.com/yunarta/terraform-provider-commons v1.0.1/go.mod h1:gXzBv5F0F/52m46qPp8hzYrdQSG/VScTnJXf4muldXg=
+github.com/yunarta/terraform-provider-commons v1.0.2 h1:Mvae6Tx0syaRLh4MWfnP4sTp/oM+GEauhyuQM5+QWuk=
+github.com/yunarta/terraform-provider-commons v1.0.2/go.mod h1:8jL2esDNbF7MBfmE2gbrs45NSYnDk8XfRtpkpjxgXNU=
 golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.24.0 h1:mnl8DM0o513X8fdIkmyFE/5hTYxbwYOjDS/+rK6qpRI=
 golang.org/x/crypto v0.24.0/go.mod h1:Z1PMYSOR5nyMcyAVAIQSKCDwalqy85Aqn1x3Ws4L5DM=

--- a/provider/resource_bitbucket_project.go
+++ b/provider/resource_bitbucket_project.go
@@ -8,7 +8,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/yunarta/terraform-atlassian-api-client/bitbucket"
 	"github.com/yunarta/terraform-provider-commons/util"
@@ -58,7 +57,7 @@ func (receiver *ProjectResource) Schema(ctx context.Context, request resource.Sc
 			"key": schema.StringAttribute{
 				Required: true,
 				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.RequiresReplaceIfConfigured(),
+					util.ReplaceIfStringDiff(),
 				},
 			},
 			"name": schema.StringAttribute{

--- a/provider/resource_bitbucket_project_branch_restrictions.go
+++ b/provider/resource_bitbucket_project_branch_restrictions.go
@@ -6,7 +6,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/yunarta/terraform-atlassian-api-client/bitbucket"
 	"github.com/yunarta/terraform-provider-commons/util"
@@ -47,7 +46,7 @@ func (receiver *ProjectBranchRestrictionsResource) Schema(ctx context.Context, r
 			"project": schema.StringAttribute{
 				Required: true,
 				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.RequiresReplaceIfConfigured(),
+					util.ReplaceIfStringDiff(),
 				},
 			},
 			"branch": schema.StringAttribute{

--- a/provider/resource_bitbucket_project_merge_checks.go
+++ b/provider/resource_bitbucket_project_merge_checks.go
@@ -6,7 +6,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/yunarta/terraform-atlassian-api-client/bitbucket"
 	"github.com/yunarta/terraform-provider-commons/util"
@@ -47,7 +46,7 @@ func (receiver *ProjectMergeChecksResource) Schema(ctx context.Context, request 
 			"project": schema.StringAttribute{
 				Required: true,
 				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.RequiresReplaceIfConfigured(),
+					util.ReplaceIfStringDiff(),
 				},
 			},
 			"all_reviewer_approval": schema.BoolAttribute{

--- a/provider/resource_bitbucket_project_permissions.go
+++ b/provider/resource_bitbucket_project_permissions.go
@@ -7,7 +7,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/yunarta/terraform-atlassian-api-client/bitbucket"
 	"github.com/yunarta/terraform-provider-commons/util"
@@ -54,7 +53,7 @@ func (receiver *ProjectPermissionsResource) Schema(ctx context.Context, request 
 			"key": schema.StringAttribute{
 				Required: true,
 				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.RequiresReplaceIfConfigured(),
+					util.ReplaceIfStringDiff(),
 				},
 			},
 			"assignment_version": schema.StringAttribute{

--- a/provider/resource_bitbucket_repository.go
+++ b/provider/resource_bitbucket_repository.go
@@ -78,7 +78,7 @@ func (receiver *RepositoryResource) Schema(ctx context.Context, request resource
 			"name": schema.StringAttribute{
 				Required: true,
 				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.RequiresReplaceIfConfigured(),
+					util.ReplaceIfStringDiff(),
 				},
 				Validators: []validator.String{
 					stringvalidator.RegexMatches(
@@ -95,7 +95,7 @@ func (receiver *RepositoryResource) Schema(ctx context.Context, request resource
 			"project": schema.StringAttribute{
 				Required: true,
 				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.RequiresReplaceIfConfigured(),
+					util.ReplaceIfStringDiff(),
 				},
 			},
 			"readme": schema.StringAttribute{

--- a/provider/resource_bitbucket_repository_branch_restrictions.go
+++ b/provider/resource_bitbucket_repository_branch_restrictions.go
@@ -6,7 +6,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/yunarta/terraform-atlassian-api-client/bitbucket"
 	"github.com/yunarta/terraform-provider-commons/util"
@@ -47,13 +46,13 @@ func (receiver *RepositoryBranchRestrictionsResource) Schema(ctx context.Context
 			"project": schema.StringAttribute{
 				Required: true,
 				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.RequiresReplaceIfConfigured(),
+					util.ReplaceIfStringDiff(),
 				},
 			},
 			"repo": schema.StringAttribute{
 				Required: true,
 				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.RequiresReplaceIfConfigured(),
+					util.ReplaceIfStringDiff(),
 				},
 			},
 			"branch": schema.StringAttribute{

--- a/provider/resource_bitbucket_repository_merge_checks.go
+++ b/provider/resource_bitbucket_repository_merge_checks.go
@@ -6,7 +6,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/yunarta/terraform-atlassian-api-client/bitbucket"
 	"github.com/yunarta/terraform-provider-commons/util"
@@ -47,13 +46,13 @@ func (receiver *RepositoryMergeChecksResource) Schema(ctx context.Context, reque
 			"project": schema.StringAttribute{
 				Required: true,
 				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.RequiresReplaceIfConfigured(),
+					util.ReplaceIfStringDiff(),
 				},
 			},
 			"repo": schema.StringAttribute{
 				Required: true,
 				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.RequiresReplaceIfConfigured(),
+					util.ReplaceIfStringDiff(),
 				},
 			},
 			"all_reviewer_approval": schema.BoolAttribute{


### PR DESCRIPTION
Upgraded the version of 'terraform-provider-commons' from v1.0.1 to v1.0.2 in go.sum and go.mod. In several files, replaced 'stringplanmodifier.RequiresReplaceIfConfigured()' with 'util.ReplaceIfStringDiff()'. Changes streamline diffs and provide better modification planning.