### PR TITLE
Fix issue where importing repository and then apply causing repository to be recreated

### DIFF
--- a/provider/repository_model.go
+++ b/provider/repository_model.go
@@ -41,7 +41,7 @@ func NewRepositoryModel(repository *bitbucket.Repository, plan RepositoryModel, 
 	return &RepositoryModel{
 		ID:                types.StringValue(fmt.Sprintf("%v", repository.ID)),
 		Slug:              types.StringValue(repository.Slug),
-		Name:              plan.Name,
+		Name:              types.StringValue(repository.Name),
 		Description:       plan.Description,
 		Project:           plan.Project,
 		RetainOnDelete:    plan.RetainOnDelete,


### PR DESCRIPTION
The revision changes how the repository name is assigned in the RepositoryModel. Instead of using the previously referenced 'plan.Name', the code now uses 'types.StringValue(repository.Name)' for better coherency and accuracy.