### PR TITLE
Add support for repository default reviewers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/hashicorp/terraform-plugin-framework-validators v0.12.0
 	github.com/yunarta/golang-quality-of-life-pack v1.0.0
 	github.com/yunarta/terraform-api-transport v1.0.1
-	github.com/yunarta/terraform-atlassian-api-client v1.3.13
+	github.com/yunarta/terraform-atlassian-api-client v1.3.16
 	github.com/yunarta/terraform-provider-commons v1.0.3
 )
 

--- a/go.sum
+++ b/go.sum
@@ -118,8 +118,8 @@ github.com/yunarta/golang-quality-of-life-pack v1.0.0 h1:T0xwfFnD61x6Nz9ej+tRWK6
 github.com/yunarta/golang-quality-of-life-pack v1.0.0/go.mod h1:Qw+9tWyqPJxxHLyuxCo5xCNwmfG/TMOt8Vkfq0bl9TU=
 github.com/yunarta/terraform-api-transport v1.0.1 h1:WzxCUGs8UJcCYB09ErLLXtu8NGzKIoCfWNlLQTjnYA4=
 github.com/yunarta/terraform-api-transport v1.0.1/go.mod h1:sYdlgKir9SBUVv3GO/m5m7MtJ5o9FK/n4yRpQKmFvjM=
-github.com/yunarta/terraform-atlassian-api-client v1.3.13 h1:Qw62vzMKh6zyZvK6MChJ3bFLNtFUeth7QoPP+XNHsPU=
-github.com/yunarta/terraform-atlassian-api-client v1.3.13/go.mod h1:QOj00CmhhXF+6kb8RBxEULIBEaZe0Bv+xMFmFHCHUIA=
+github.com/yunarta/terraform-atlassian-api-client v1.3.16 h1:romFzg3xG2XdKQBQTEjcJPBDSBFvPE0Jqg2nNlvNA10=
+github.com/yunarta/terraform-atlassian-api-client v1.3.16/go.mod h1:QOj00CmhhXF+6kb8RBxEULIBEaZe0Bv+xMFmFHCHUIA=
 github.com/yunarta/terraform-provider-commons v1.0.3 h1:+eHAfpObrOr3WKvGhZzZAYsPphiMmZOiF1pHhF82lOQ=
 github.com/yunarta/terraform-provider-commons v1.0.3/go.mod h1:8jL2esDNbF7MBfmE2gbrs45NSYnDk8XfRtpkpjxgXNU=
 golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=

--- a/main.go
+++ b/main.go
@@ -17,6 +17,10 @@ var (
 	// https://goreleaser.com/cookbooks/using-main.version/
 )
 
+// Run the docs generation tool, check its repository for more information on how it works and how docs
+// can be customized.
+//go:generate go run github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs generate -provider-name bitbucket
+
 func main() {
 	var debug bool
 

--- a/provider/default_reviewers.go
+++ b/provider/default_reviewers.go
@@ -1,0 +1,13 @@
+package provider
+
+var refTypes = []string{"any", "pattern", "branch"}
+var refTypesMap = map[string]string{
+	"any":     "ANY_REF",
+	"pattern": "PATTERN",
+	"branch":  "BRANCH",
+}
+var refTypesReverseMap = map[string]string{
+	"ANY_REF": "any",
+	"PATTERN": "pattern",
+	"BRANCH":  "branch",
+}

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -132,6 +132,7 @@ func (p *BitbucketProvider) Resources(ctx context.Context) []func() resource.Res
 		NewRepositoryPermissionsResource,
 		NewRepositoryBranchRestrictionsResource,
 		NewRepositoryMergeChecksResource,
+		NewRepositoryDefaultReviewersResource,
 	}
 }
 

--- a/provider/repository_default_reviewers.go
+++ b/provider/repository_default_reviewers.go
@@ -1,0 +1,15 @@
+package provider
+
+import "github.com/hashicorp/terraform-plugin-framework/types"
+
+type RepositoryDefaultReviewersModel struct {
+	Id         types.Int64  `tfsdk:"id"`
+	Project    types.String `tfsdk:"project"`
+	Repository types.String `tfsdk:"repository"`
+	Source     types.String `tfsdk:"source"`
+	SourceType types.String `tfsdk:"source_type"`
+	Target     types.String `tfsdk:"target"`
+	TargetType types.String `tfsdk:"target_type"`
+	Reviewers  []string     `tfsdk:"reviewers"`
+	Requires   types.Int64  `tfsdk:"requires"`
+}


### PR DESCRIPTION
Implement a new resource for repository default reviewers within the Terraform provider. This includes creating a new Go file with schema definitions and CRUD operations to manage default reviewers in Bitbucket repositories. The update also refactors existing code structure to accommodate this new functionality.