### PR TITLE
Update checksum for terraform-atlassian-api-client

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -118,7 +118,7 @@ github.com/yunarta/golang-quality-of-life-pack v1.0.0 h1:T0xwfFnD61x6Nz9ej+tRWK6
 github.com/yunarta/golang-quality-of-life-pack v1.0.0/go.mod h1:Qw+9tWyqPJxxHLyuxCo5xCNwmfG/TMOt8Vkfq0bl9TU=
 github.com/yunarta/terraform-api-transport v1.0.1 h1:WzxCUGs8UJcCYB09ErLLXtu8NGzKIoCfWNlLQTjnYA4=
 github.com/yunarta/terraform-api-transport v1.0.1/go.mod h1:sYdlgKir9SBUVv3GO/m5m7MtJ5o9FK/n4yRpQKmFvjM=
-github.com/yunarta/terraform-atlassian-api-client v1.3.16 h1:romFzg3xG2XdKQBQTEjcJPBDSBFvPE0Jqg2nNlvNA10=
+github.com/yunarta/terraform-atlassian-api-client v1.3.16 h1:guOafW/7hDFsf0KoLcYYzHEbi7fbIrexx5qipsGSQdo=
 github.com/yunarta/terraform-atlassian-api-client v1.3.16/go.mod h1:QOj00CmhhXF+6kb8RBxEULIBEaZe0Bv+xMFmFHCHUIA=
 github.com/yunarta/terraform-provider-commons v1.0.3 h1:+eHAfpObrOr3WKvGhZzZAYsPphiMmZOiF1pHhF82lOQ=
 github.com/yunarta/terraform-provider-commons v1.0.3/go.mod h1:8jL2esDNbF7MBfmE2gbrs45NSYnDk8XfRtpkpjxgXNU=


### PR DESCRIPTION
Corrects the checksum for the terraform-atlassian-api-client v1.3.16 in the go.sum file. Ensures dependency integrity by matching the server-side version, preventing potential build errors. This change does not alter the functionality or dependencies of the project beyond updating the checksum.