### PR TITLE
Add repository data source and refactor repository permissions

### DIFF
--- a/provider/constants.go
+++ b/provider/constants.go
@@ -3,6 +3,7 @@ package provider
 const errorFailedToUpdateState = "Failed to update resource state"
 
 const errorFailedToCreateRepository = "Failed to create repository"
+const errorFailedToReadRepository = "Failed to read repository"
 const errorFailedToUpdateRepository = "Failed to update repository"
 const errorFailedToDeleteRepository = "Failed to delete repository"
 const errorFailedToInitializeRepository = "Failed to initialize repository"

--- a/provider/data_repository.go
+++ b/provider/data_repository.go
@@ -1,0 +1,86 @@
+package provider
+
+import (
+	"context"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/yunarta/terraform-atlassian-api-client/bitbucket"
+	"github.com/yunarta/terraform-provider-commons/util"
+)
+
+type RepositoryData struct {
+	Project string     `tfsdk:"project"`
+	Slug    string     `tfsdk:"slug"`
+	Exists  types.Bool `tfsdk:"exists"`
+}
+
+var (
+	_ datasource.DataSource              = &RepositoryDataSource{}
+	_ datasource.DataSourceWithConfigure = &RepositoryDataSource{}
+	_ ConfigurableReceiver               = &RepositoryDataSource{}
+)
+
+func NewRepositoryDataSource() datasource.DataSource {
+	return &RepositoryDataSource{}
+}
+
+type RepositoryDataSource struct {
+	config BitbucketProviderConfig
+	client *bitbucket.Client
+}
+
+func (receiver *RepositoryDataSource) setConfig(config BitbucketProviderConfig, client *bitbucket.Client) {
+	receiver.config = config
+	receiver.client = client
+}
+
+func (receiver *RepositoryDataSource) Configure(ctx context.Context, request datasource.ConfigureRequest, response *datasource.ConfigureResponse) {
+	ConfigureDataSource(receiver, ctx, request, response)
+}
+
+func (receiver *RepositoryDataSource) Metadata(ctx context.Context, request datasource.MetadataRequest, response *datasource.MetadataResponse) {
+	response.TypeName = request.ProviderTypeName + "_repository"
+}
+
+func (receiver *RepositoryDataSource) Schema(ctx context.Context, request datasource.SchemaRequest, response *datasource.SchemaResponse) {
+	response.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"project": schema.StringAttribute{
+				Required: true,
+			},
+			"slug": schema.StringAttribute{
+				Required: true,
+			},
+			"exists": schema.BoolAttribute{
+				Computed: true,
+			},
+		},
+	}
+}
+
+func (receiver *RepositoryDataSource) Read(ctx context.Context, request datasource.ReadRequest, response *datasource.ReadResponse) {
+	var (
+		diags diag.Diagnostics
+		err   error
+
+		config RepositoryData
+	)
+
+	diags = request.Config.Get(ctx, &config)
+	if util.TestDiagnostic(&response.Diagnostics, diags) {
+		return
+	}
+
+	_, err = receiver.client.RepositoryService().Read(config.Project, config.Slug)
+
+	diags = response.State.Set(ctx, &RepositoryData{
+		Project: config.Project,
+		Slug:    config.Slug,
+		Exists:  types.BoolValue(err == nil),
+	})
+	if util.TestDiagnostic(&response.Diagnostics, diags) {
+		return
+	}
+}

--- a/provider/data_repository_permissions.go
+++ b/provider/data_repository_permissions.go
@@ -11,10 +11,10 @@ import (
 )
 
 type RepositoryPermissionsData struct {
-	Key    string              `tfsdk:"key"`
-	Slug   string              `tfsdk:"slug"`
-	Users  map[string][]string `tfsdk:"users"`
-	Groups map[string][]string `tfsdk:"groups"`
+	Project string              `tfsdk:"project"`
+	Slug    string              `tfsdk:"slug"`
+	Users   map[string][]string `tfsdk:"users"`
+	Groups  map[string][]string `tfsdk:"groups"`
 }
 
 var (
@@ -48,7 +48,7 @@ func (receiver *RepositoryPermissionsDataSource) Metadata(ctx context.Context, r
 func (receiver *RepositoryPermissionsDataSource) Schema(ctx context.Context, request datasource.SchemaRequest, response *datasource.SchemaResponse) {
 	response.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
-			"key": schema.StringAttribute{
+			"project": schema.StringAttribute{
 				Required: true,
 			},
 			"slug": schema.StringAttribute{
@@ -81,13 +81,13 @@ func (receiver *RepositoryPermissionsDataSource) Read(ctx context.Context, reque
 		return
 	}
 
-	permissions, err := receiver.client.RepositoryService().ReadPermissions(config.Key, config.Slug)
+	permissions, err := receiver.client.RepositoryService().ReadPermissions(config.Project, config.Slug)
 	if util.TestError(&response.Diagnostics, err, "") {
 		return
 	}
 
 	if permissions == nil {
-		response.Diagnostics.AddError("Unable to find deployment", config.Key)
+		response.Diagnostics.AddError("Unable to find deployment", config.Project)
 		return
 	}
 
@@ -97,9 +97,9 @@ func (receiver *RepositoryPermissionsDataSource) Read(ctx context.Context, reque
 	}
 
 	diags = response.State.Set(ctx, &RepositoryPermissionsData{
-		Key:    config.Key,
-		Users:  users,
-		Groups: groups,
+		Project: config.Project,
+		Users:   users,
+		Groups:  groups,
 	})
 	if util.TestDiagnostic(&response.Diagnostics, diags) {
 		return

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -116,6 +116,7 @@ func (p *BitbucketProvider) Configure(ctx context.Context, request provider.Conf
 
 func (p *BitbucketProvider) DataSources(ctx context.Context) []func() datasource.DataSource {
 	return []func() datasource.DataSource{
+		NewRepositoryDataSource,
 		NewRepositoryPermissionsDataSource,
 		NewProjectPermissionsDataSource,
 	}


### PR DESCRIPTION
Introduced a new `repository` data source to manage repository existence checks. Updated `repository_permissions` data source to replace the `key` attribute with `project` for clarity and consistency. Added a new error constant and registered the `repository` data source in the provider.