### PR TITLE
Update terraform-atlassian-api-client to v1.3.21

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/hashicorp/terraform-plugin-framework-validators v0.16.0
 	github.com/yunarta/golang-quality-of-life-pack v1.0.0
 	github.com/yunarta/terraform-api-transport v1.0.2
-	github.com/yunarta/terraform-atlassian-api-client v1.3.20
+	github.com/yunarta/terraform-atlassian-api-client v1.3.21
 	github.com/yunarta/terraform-provider-commons v1.0.3
 )
 

--- a/go.sum
+++ b/go.sum
@@ -118,8 +118,8 @@ github.com/yunarta/golang-quality-of-life-pack v1.0.0 h1:T0xwfFnD61x6Nz9ej+tRWK6
 github.com/yunarta/golang-quality-of-life-pack v1.0.0/go.mod h1:Qw+9tWyqPJxxHLyuxCo5xCNwmfG/TMOt8Vkfq0bl9TU=
 github.com/yunarta/terraform-api-transport v1.0.2 h1:uJ3+gAblwPWc4dVGD8ku7X4wLfUzi+pCC+dLS54JdiU=
 github.com/yunarta/terraform-api-transport v1.0.2/go.mod h1:uQshZ/gKlszLfamYY+y+4pAnxnOtzg6XC2zn63h8ZT4=
-github.com/yunarta/terraform-atlassian-api-client v1.3.20 h1:EQLX++IgPcIRJizZ5cDm6+nVrw3AGLD2koRj45l/lIE=
-github.com/yunarta/terraform-atlassian-api-client v1.3.20/go.mod h1:uu8we0EQNUX9WdZReegMzN/jEANZUW7m42WZhYj7rOc=
+github.com/yunarta/terraform-atlassian-api-client v1.3.21 h1:iRvzbt5zQDeRbQc9wp+VTbxjPPeE8+TATymYgcruMdQ=
+github.com/yunarta/terraform-atlassian-api-client v1.3.21/go.mod h1:uu8we0EQNUX9WdZReegMzN/jEANZUW7m42WZhYj7rOc=
 github.com/yunarta/terraform-provider-commons v1.0.3 h1:+eHAfpObrOr3WKvGhZzZAYsPphiMmZOiF1pHhF82lOQ=
 github.com/yunarta/terraform-provider-commons v1.0.3/go.mod h1:8jL2esDNbF7MBfmE2gbrs45NSYnDk8XfRtpkpjxgXNU=
 golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=


### PR DESCRIPTION
Upgraded the dependency from v1.3.20 to v1.3.21 in both `go.mod` and `go.sum`. This ensures compatibility with the latest changes and improvements in the library.